### PR TITLE
Fix: correct default user in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,6 +62,6 @@ RUN apt update && apt install -y /origin-msgs_arm64_1.0.1.deb
 # RUN sudo apt update && sudo apt install -y \
 #     <package you want to install>
 
-USER USER
+USER user
 WORKDIR /home/user/ws
 CMD ["/bin/bash"]


### PR DESCRIPTION
The Dockerfile indicated the default user should be USER, but such a user does not exist: only a user `user` exists. Updated to instead refer to the `user` user as the default user.