### PR TITLE
feat: update Creos SDK version to 0.4.0 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,12 +59,13 @@ RUN sudo chmod 0755 /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
 
 # Install Creos
-RUN wget https://avular.blob.core.windows.net/creos/creos-sdk-0.2.2-arm64.zip \
-    && unzip creos-sdk-0.2.2-arm64.zip \
+RUN wget https://avular.blob.core.windows.net/creos/creos_sdk_0.4.0_jammy_arm64.zip \
+    && unzip creos_sdk_0.4.0_jammy_arm64.zip \
     && apt update \
+    && cd creos_sdk_client_package_Release_jammy_arm64 \
     && dpkg -i creos-*_*_arm64.deb \
     && rm creos-*_*_arm64.deb \
-    && rm creos-sdk-0.2.2-arm64.zip
+    && rm creos_sdk_0.4.0_jammy_arm64.zip
 
 WORKDIR /home/user/ws
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,8 @@ RUN wget https://avular.blob.core.windows.net/creos/creos_sdk_0.4.0_jammy_arm64.
     && apt update \
     && cd creos_sdk_client_package_Release_jammy_arm64 \
     && dpkg -i creos-*_*_arm64.deb \
-    && rm creos-*_*_arm64.deb \
+    && cd .. \
+    && rm -rf creos_sdk_client_package_Release_jammy_arm64 \
     && rm creos_sdk_0.4.0_jammy_arm64.zip
 
 WORKDIR /home/user/ws


### PR DESCRIPTION
This pull request updates the installation process for the Creos SDK in the `Dockerfile` to use a newer version and adjusts the installation steps accordingly.

Dependency upgrade and installation process:

* Updated the Creos SDK download link from version `0.2.2-arm64` to `0.4.0_jammy_arm64` to use the latest available version.
* Modified the installation steps to change the directory into `creos_sdk_client_package_Release_jammy_arm64` before running the package installation, aligning with the new SDK package structure.
* Updated cleanup commands to remove the new SDK zip file after installation.