### PR TITLE
Fix: Docker build in release workflow

### DIFF
--- a/.github/workflows/release-container.yml
+++ b/.github/workflows/release-container.yml
@@ -43,3 +43,5 @@ jobs:
             ghcr.io/avular-robotics/user-container:vertex-latest
             ghcr.io/avular-robotics/user-container:${{ steps.version.outputs.version }}
         platforms: linux/arm64
+        cache-from: type=gha
+        cache-to: type=gha,mode=max


### PR DESCRIPTION
This pull request fixes the container release workflow but using caching parameters:

The problem was because the cache-to parameter syntax has changed in newer versions of Docker Buildx.

