### PR TITLE
feat: update Creos SDK version to 0.5.0 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,14 +59,14 @@ RUN sudo chmod 0755 /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
 
 # Install Creos
-RUN wget https://avular.blob.core.windows.net/creos/creos_sdk_0.4.0_jammy_arm64.zip \
-    && unzip creos_sdk_0.4.0_jammy_arm64.zip \
+RUN wget https://avular.blob.core.windows.net/creos/creos_sdk_0.5.0_jammy_arm64.zip \
+    && unzip creos_sdk_0.5.0_jammy_arm64.zip \
     && apt update \
     && cd creos_sdk_client_package_Release_jammy_arm64 \
     && dpkg -i creos-*_*_arm64.deb \
     && cd .. \
     && rm -rf creos_sdk_client_package_Release_jammy_arm64 \
-    && rm creos_sdk_0.4.0_jammy_arm64.zip
+    && rm creos_sdk_*.*.*_jammy_arm64.zip
 
 WORKDIR /home/user/ws
 


### PR DESCRIPTION
This pull request updates the Dockerfile to use a newer version of the Creos SDK. The main change is upgrading from version 0.4.0 to 0.5.0, which ensures the container uses the latest SDK features and fixes.

Dependency update:

* Updated the Creos SDK installation in the `Dockerfile` from version 0.4.0 to 0.5.0, including adjustments to the downloaded and removed zip file names.