### PR TITLE
feat: update Creos SDK version to 0.6.0 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,8 +59,8 @@ RUN sudo chmod 0755 /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
 
 # Install Creos
-RUN wget https://avular.blob.core.windows.net/creos/creos_sdk_0.5.0_jammy_arm64.zip \
-    && unzip creos_sdk_0.5.0_jammy_arm64.zip \
+RUN wget https://avular.blob.core.windows.net/creos/creos_sdk_0.6.0_jammy_arm64.zip \
+    && unzip creos_sdk_0.6.0_jammy_arm64.zip \
     && apt update \
     && cd creos_sdk_client_package_Release_jammy_arm64 \
     && dpkg -i creos-*_*_arm64.deb \

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ RUN apt-get update \
     ros-${ROS_DISTRO}-rviz2 \
     ros-${ROS_DISTRO}-rmw-cyclonedds-cpp \
     ros-${ROS_DISTRO}-nav-msgs \
+    ros-${ROS_DISTRO}-nav2-msgs \
     bash-completion \
     # Creos dependencies
     nlohmann-json3-dev \


### PR DESCRIPTION
This pull request makes a minor update to the Dockerfile by upgrading the Creos SDK to a newer version.

- Updated the Dockerfile to download and install `creos_sdk_0.6.0_jammy_arm64.zip` instead of the previous `0.5.0` version, ensuring the container uses the latest Creos SDK.